### PR TITLE
Add Image Links for Textbooks on Syllabus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ book_opt_3_author: "Greg DeKoenigsberg, Chris Tyler, Karsten Wade, Max Spevack, 
 book_opt_3_edition: ""
 book_opt_3_link: "https://quaid.fedorapeople.org/TOS/Practical_Open_Source_Software_Exploration/html/"
 book_opt_3_note: "(it hasn't been updated since 2010, but there is some good stuff in there)"
-book_opt_3_image: ""
+book_opt_3_image: "https://quaid.fedorapeople.org/TOS/Practical_Open_Source_Software_Exploration/html/Common_Content/images/image_left.png"
 
 
 book_opt_4: "The Linux Command Line, "
@@ -81,7 +81,7 @@ book_opt_4_author: "William Shotts, "
 book_opt_4_edition: ""
 book_opt_4_link: "http://linuxcommand.org/tlcl.php"
 book_opt_4_note: ""
-book_opt_4_image: ""
+book_opt_4_image: "http://linuxcommand.org/images/lcl2_front_new.png"
 
 
 book_opt_5: "ProGit, "


### PR DESCRIPTION
In _config.yml the book_opt_3_image and book_opt_4_image variables were empty, this pull request populates them with relevant links to images that match the corresponding text books.

Resolves #7 
@BradFeng02 and @joannakl Let me know how this looks.
Link to my fork: [JacobLBaum/ossd](https://github.com/JacobLBaum/ossd)