### PR TITLE
fixed typo in week2 assignments

### DIFF
--- a/_includes/daily/week2.markdown
+++ b/_includes/daily/week2.markdown
@@ -75,7 +75,7 @@ on an add-on project
 
 Due by the end of the week (i.e., Sunday)
 <br>[Jim Hall](https://hallmentum.com/about/jimhall/) will be our first invited speaker this semester.
-He is a maintainer of the [FeeDOS](https://www.freedos.org/) project, among other things.
+He is a maintainer of the [FreeDOS](https://www.freedos.org/) project, among other things.
 - read two or three articles published by Jim on [OpenSource.com](https://opensource.com/users/jim-hall) site
 - add a question for Jim,  to the course wiki
   - add your own question, and enter a number 1 next to it


### PR DESCRIPTION
In _includes/daily/week2.markdown, "FreeDOS" is misspelled as "FeeDOS", which has been corrected in this pull request.

Resolves https://github.com/joannakl/ossd/issues/6

My fork: [kzhang01/ossd](https://github.com/kzhang01/ossd)