### PR TITLE
Textbook Publisher Typo Fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -95,7 +95,7 @@ book_opt_6: "The Cathedral and the Bazaar, "
 book_opt_6_author: "Eric Steven Raymond, "
 book_opt_6_edition: ""
 book_opt_6_link: "http://www.catb.org/~esr/writings/cathedral-bazaar/"
-book_opt_6_note: "printed version available from [O'Railly](http://shop.oreilly.com/product/9781565927247.do)"
+book_opt_6_note: "printed version available from [O'Reilly](http://shop.oreilly.com/product/9781565927247.do)"
 book_opt_6_image: "https://upload.wikimedia.org/wikipedia/en/c/c4/Cathedral-and-the-Bazaar-book-cover.jpg"
 
 


### PR DESCRIPTION
Changed O'Railly to O'Reilly resolving issue #34 