### PR TITLE
fixed empty book_opt_4_image

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -80,7 +80,7 @@ book_opt_4_author: "William Shotts, "
 book_opt_4_edition: ""
 book_opt_4_link: "http://linuxcommand.org/tlcl.php"
 book_opt_4_note: ""
-book_opt_4_image: ""
+book_opt_4_image: "http://linuxcommand.org/images/lcl2_front_new.png"
 
 
 book_opt_5: "ProGit, "


### PR DESCRIPTION
Resolves #7  issue
filled book_opt_4_image with link to the image "http://linuxcommand.org/images/lcl2_front_new.png"