### PR TITLE
Removed and updated broken links in Week 7 "history" slide

### DIFF
--- a/slides/history.html
+++ b/slides/history.html
@@ -212,11 +212,9 @@ improvements they made to the system. As Stallman wrote later: _
 
 - [History of OSI](https://opensource.org/history), OSI = Open Source Initiative
 
-- [History of Open Source](https://www.longsight.com/learning-center/history-open-source)
-
 - [History of Free and Open Source Software](https://learn.canvas.net/courses/4/pages/history-of-free-and-open-source-software)
 
-- [The 9 most important events in open source history](http://royal.pingdom.com/2010/01/15/the-9-most-important-events-in-open-source-history/)
+- [The 9 most important events in open source history](https://www.longsight.com/learning-center/history-open-source)
 
 - [GPL ver 1 license](https://www.gnu.org/licenses/old-licenses/gpl-1.0.html)
 


### PR DESCRIPTION
Set the correct link to "The 9 most important events in open source history" to the correct one "https://www.pingdom.com/blog/the-9-most-important-events-in-open-source-history/".
Removed the reference to "History of Open Source" since the link is broken and cannot be found.

Closes issue #66 