### PR TITLE
Update branch terminology to 'main'

### DIFF
--- a/slides/version_control_systems.html
+++ b/slides/version_control_systems.html
@@ -99,7 +99,7 @@ __Show of hands:__
 --
 
     A database in which changes are stored and from which they are published. <br>
-    In a __centralized VCS__, there is a single, master repository. <br>
+    In a __centralized VCS__, there is a single, main repository. <br>
     In a __distributed__ or __decentralized VCS__, each developer has their own
     repository, and changes can be interchanged among repositories arbitrarily.
 
@@ -447,9 +447,9 @@ that a __merge conflict__ exists and must be resolved manually.
 
           `git push origin`
 
-        For even more clarity, you are pushing your __master branch__ and can use
+        For even more clarity, you are pushing your __main branch__ and can use
 
-          `git push origin master`
+          `git push origin main`
 
 ---
 


### PR DESCRIPTION
I replaced 'master' with 'main' for the branch naming convention in the slides.
