### PR TITLE
Added headers for edstem and brightspace

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,5 @@
-
 <header>
-    <h1>{{ site.title }}  </h1>
+    <h1>{{ site.title }} </h1>
 </header>
 
 
@@ -10,6 +9,8 @@
         <li><a href="daily.html">Daily</a></li>
         <li><a href="{{site.github_site}}" target="_blank">GitHub Class Organization</a></li>
         <li><a href="{{site.website_github_site}}" target="_blank">Website GitHub</a></li>
-        
+        <li><a href="https://edstem.org/us/dashboard" target="_blank">EdStem</a></li>
+        <li><a href="https://brightspace.nyu.edu/" target="_blank">Brightspace</a></li>
+
     </ul>
 </nav>


### PR DESCRIPTION
As discussed in #69 , I added the headers for edstem and brightspace. In addition to that, I was also wondering if there is any particular reason that these link has to be general and not specific to the class. If it is because it has to be changed every semester, could we promote these links into config variables and link them at the appropriate places? 