### PR TITLE
Fixed typo in grading section of homepage 

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -103,7 +103,7 @@ Grades will be determined using the following scale:
         F   less than 65
 
 
-The grade of *Incomplete* is reserved for students who, for legitimate and documented reason, miss the final exam. The grade of *Incomplete* **will not be given** to student who started falling behind in class. Those students should withdraw from the class or switch to *Pass/Fail* option.
+The grade of *Incomplete* is reserved for students who, for legitimate and documented reason, miss the final exam. The grade of *Incomplete* **will not be given** to students who started falling behind in class. Those students should withdraw from the class or switch to *Pass/Fail* option.
 
 
 


### PR DESCRIPTION
This PR fixes a small typo in the grading section of the homepage where "student" was used instead of "students."

Closes #150.